### PR TITLE
Fix: YOLOE export emits dense predictions (bypass NMS-free head); rename to export_yoloe-26

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,14 +115,14 @@ python3 scripts/export_yolo26.py -w models/yolo26m.pt --simplify
 
 # Option B — open-vocab YOLOE-26 (detection, you pick the classes)
 python3 scripts/download_model.py --model yoloe --size m
-python3 scripts/export_yoloe.py \
+python3 scripts/export_yoloe-26.py \
     -w models/yoloe-26m-seg.pt \
     --custom-classes "vehicle,person,motorcycle,traffic_sign,traffic_light,truck,bus,bicycle" \
     --dynamic --simplify
 # → models/yoloe-26m-seg.onnx + models/yoloe-26m-seg.labels.txt
 
 # Option C — open-vocab YOLOE-26 (segmentation, masks in OSD output)
-python3 scripts/export_yoloe_seg.py \
+python3 scripts/export_yoloe-26-seg.py \
     -w models/yoloe-26m-seg.pt \
     --custom-classes "vehicle,person,motorcycle,traffic_sign,traffic_light,truck,bus,bicycle" \
     --dynamic --simplify --build-engine
@@ -203,8 +203,8 @@ DeepStream-VLM/
 ├── scripts/
 │   ├── download_model.py                 # fetch yolo26 / yoloe weights
 │   ├── export_yolo26.py                  # closed-vocab ONNX export
-│   ├── export_yoloe.py                   # open-vocab detect ONNX export
-│   └── export_yoloe_seg.py               # open-vocab seg ONNX + trtexec engine
+│   ├── export_yoloe-26.py               # open-vocab detect ONNX export
+│   └── export_yoloe-26-seg.py           # open-vocab seg ONNX + trtexec engine
 ├── configs/
 │   ├── config_infer_yolo26.txt           # nvinfer: YOLO26 (closed)
 │   ├── config_infer_yolo26e.txt          # nvinfer: YOLOE detect (open)

--- a/scripts/download_model.py
+++ b/scripts/download_model.py
@@ -2,8 +2,8 @@
 
 Ultralytics publishes YOLOE only as the seg checkpoint (no detect-only `.pt`);
 the same ``yoloe-26{size}-seg.pt`` file feeds BOTH export scripts —
-``export_yoloe.py`` strips mask coefficients for detection-only inference,
-and ``export_yoloe_seg.py`` keeps them for instance segmentation. Pick the
+``export_yoloe-26.py`` strips mask coefficients for detection-only inference,
+and ``export_yoloe-26-seg.py`` keeps them for instance segmentation. Pick the
 script based on the nvinfer config you want to use at runtime.
 
     --model yolo26   → yolo26{size}.pt             (closed-vocab, 80 COCO classes)

--- a/scripts/export_yoloe-26-seg.py
+++ b/scripts/export_yoloe-26-seg.py
@@ -5,7 +5,7 @@ decode into the ONNX graph so DeepStream nvinfer (network-type=3) can produce
 instance masks directly without post-processing.
 
 Usage (inside container):
-    python3 scripts/export_yoloe_seg.py \\
+    python3 scripts/export_yoloe-26-seg.py \\
         -w models/yoloe-26m-seg.pt \\
         --custom-classes "vehicle,person" \\
         --dynamic --simplify
@@ -17,6 +17,7 @@ Paired with ``configs/config_infer_yolo26e_seg.txt`` and
 
 import os
 import sys
+import types
 from copy import deepcopy
 
 import onnx
@@ -40,6 +41,28 @@ def _dist2bbox(distance, anchor_points, xywh=False, dim=-1):
 
 
 _m.dist2bbox.__code__ = _dist2bbox.__code__
+
+
+def forward_deepstream_seg(self, x):
+    """Emit DENSE seg predictions ``([B, 4+nc+mask_coeffs, 8400], proto)``, bypassing
+    the YOLO26/YOLOE NMS-free (end2end) head whose native output is
+    ``([B, max_det, attrs], proto)``. The downstream DeepStreamOutput expects the
+    dense per-anchor tensor as ``x[0]`` (it runs its own EfficientNMSX_TRT); without
+    this override the post-NMS tensor is fed instead and the anchor dim collapses.
+    Detection half mirrors export_yolo26.forward_deepstream; ``self.proto(x)`` adds
+    the mask prototypes as ``x[1]``."""
+    proto = self.proto(x)  # mask prototypes; proto module consumes the full feature list
+    x_detach = [xi.detach() for xi in x]
+    if hasattr(self, "inference"):
+        one2one = [
+            torch.cat((self.one2one_cv2[i](x_detach[i]), self.one2one_cv3[i](x_detach[i])), 1)
+            for i in range(self.nl)
+        ]
+        y = self.inference(one2one)
+    else:
+        one2one = self.forward_head(x_detach, **self.one2one)
+        y = self._inference(one2one)
+    return (y, proto)
 
 
 class RoiAlign(torch.autograd.Function):
@@ -217,7 +240,7 @@ def yoloe_seg_export(weights, device, custom_classes, fuse=False):
 
     # Skip Conv+BN fusion on modern Ultralytics (≥8.4.38): it re-triggers
     # ``YOLOEDetect.fuse(txt_feats=None)`` which nulls cv2/cv3/cv4. See
-    # ``export_yoloe.py`` for details.
+    # ``export_yoloe-26.py`` for details.
     if fuse:
         inner_model = inner_model.fuse()
 
@@ -226,7 +249,12 @@ def yoloe_seg_export(weights, device, custom_classes, fuse=False):
             m.dynamic = False
             m.export = True
             m.format = "onnx"
-            m.end2end = False
+            try:
+                m.end2end = False
+            except AttributeError:
+                pass  # read-only property on ultralytics>=8.4; already non-end2end
+            # Emit dense (preds, proto) instead of the NMS-free (end2end) output.
+            m.forward = types.MethodType(forward_deepstream_seg, m)
         elif isinstance(m, (C2f, C3k2)):
             m.forward = m.forward_split
 
@@ -275,7 +303,6 @@ def main(args):
         input_names=["input"],
         output_names=["output"],
         dynamic_axes=dynamic_axes if args.dynamic else None,
-        dynamo=False,  # Ultralytics models fail with dynamo exporter on torch>=2.5
     )
 
     if args.simplify:

--- a/scripts/export_yoloe-26.py
+++ b/scripts/export_yoloe-26.py
@@ -9,7 +9,7 @@ same output tensor layout as YOLO26, so the existing
 ``libnvdsinfer_custom_impl_Yolo.so`` parser works as-is.
 
 Usage (inside container):
-    python3 scripts/export_yoloe.py \\
+    python3 scripts/export_yoloe-26.py \\
         -w models/yoloe-26m-seg.pt \\
         --custom-classes "vehicle,person,motorcycle,traffic_sign" \\
         --dynamic --simplify
@@ -21,6 +21,7 @@ weights file. Point ``configs/config_infer_yolo26e.txt`` at those paths.
 
 import os
 import sys
+import types
 from copy import deepcopy
 
 import onnx
@@ -44,6 +45,25 @@ def _dist2bbox(distance, anchor_points, xywh=False, dim=-1):
 
 
 _m.dist2bbox.__code__ = _dist2bbox.__code__
+
+
+def forward_deepstream(self, x):
+    """Emit the DENSE detection predictions [B, 4+nc(+mask), 8400], bypassing the
+    YOLO26/YOLOE NMS-free (end2end) head whose native output is [B, max_det, attrs].
+    Without this override the exported ONNX carries the post-NMS tensor and the
+    DeepStream parser mis-reads it (the anchor dimension collapses, e.g. 8400->38).
+    Mirrors export_yolo26.forward_deepstream."""
+    x_detach = [xi.detach() for xi in x]
+    if hasattr(self, "inference"):
+        one2one = [
+            torch.cat((self.one2one_cv2[i](x_detach[i]), self.one2one_cv3[i](x_detach[i])), 1)
+            for i in range(self.nl)
+        ]
+        y = self.inference(one2one)
+    else:
+        one2one = self.forward_head(x_detach, **self.one2one)
+        y = self._inference(one2one)
+    return y
 
 
 class DeepStreamOutput(nn.Module):
@@ -103,7 +123,12 @@ def yoloe_export(weights, device, custom_classes, fuse=False):
             m.dynamic = False
             m.export = True
             m.format = "onnx"
-            m.end2end = False
+            try:
+                m.end2end = False
+            except AttributeError:
+                pass  # read-only property on ultralytics>=8.4; already non-end2end
+            # Emit dense predictions instead of the NMS-free (end2end) output.
+            m.forward = types.MethodType(forward_deepstream, m)
         elif isinstance(m, (C2f, C3k2)):
             m.forward = m.forward_split
 
@@ -149,7 +174,6 @@ def main(args):
         input_names=["input"],
         output_names=["output"],
         dynamic_axes=dynamic_axes if args.dynamic else None,
-        dynamo=False,  # Ultralytics models fail with dynamo exporter on torch>=2.5
     )
 
     if args.simplify:

--- a/src/vllm_ds_app_kafka_publish.py
+++ b/src/vllm_ds_app_kafka_publish.py
@@ -793,7 +793,7 @@ Examples:
             print("  Export first (inside container):")
             if "yoloe" in nvinfer_config.lower() or "yolo26e" in nvinfer_config.lower():
                 print(
-                    "  python3 /workspace/scripts/export_yoloe.py "
+                    "  python3 /workspace/scripts/export_yoloe-26.py "
                     '-w /workspace/models/yoloe-26m-seg.pt --custom-classes "vehicle,person" '
                     "--dynamic --simplify"
                 )


### PR DESCRIPTION
## Summary

- Fix `scripts/export_yoloe.py` / `export_yoloe_seg.py`: the exported ONNX carried the
  YOLO26/YOLOE **NMS-free (end2end)** output `[B, max_det, attrs]` instead of the dense
  `[B, 4+nc(+mask), 8400]` grid the DeepStream `NvDsInferParseYolo` parser expects -- the
  parser collapsed the anchor dim (`8400 -> 38`), producing garbage / oversized detection
  boxes.
- Root cause: `m.end2end = False` is a no-op because `Detect.end2end` is a **read-only
  property** on Ultralytics >=8.4. The sibling `export_yolo26.py` overrides `Detect.forward`
  to emit dense predictions; the YOLOE scripts lacked that override.
- Add `forward_deepstream` (detection) / `forward_deepstream_seg` (segmentation -- also
  returns mask `proto`) overrides reconstructing the dense one2one predictions; guard the
  read-only `end2end`; drop the `dynamo=` kwarg (absent on torch < 2.5).
- Rename to `export_yoloe-26.py` / `export_yoloe-26-seg.py` and update all references
  (README usage + layout, runtime help string, `download_model.py` docstring).

## Test Plan

- [x] Detection: re-export -> ONNX output `[1, 8400, 6]` (was `[1, 38, 6]`), confirmed via onnxruntime
- [x] Segmentation: head override -> `([1, 4+nc+32, 8400], proto[1, 32, 160, 160])` via model forward
- [x] `python3 -m py_compile` clean on both scripts
- [x] `grep` shows no stale `export_yoloe(.py|_seg.py)` references

Closes #13
